### PR TITLE
[3300] Update pipeline to remove cosmos from Build

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -377,7 +377,7 @@ stages:
 
   - stage: Prod
     dependsOn: Build
-    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -377,7 +377,7 @@ stages:
 
   - stage: Prod
     dependsOn: Build
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -259,10 +259,6 @@ stages:
                       TF_VAR_name_component: $(component),
                       TF_VAR_resource_group_location: $(region),
                       TF_VAR_create_cdn_endpoint: false,
-                      TF_VAR_cosmosdb_sql_container: "Menu",
-                      TF_VAR_cosmosdb_sql_container_partition_key: "/id",
-                      TF_VAR_cosmosdb_kind: "GlobalDocumentDB",
-                      TF_VAR_cosmosdb_offer_type: "Standard",
                       TF_VAR_create_dns_record: true,
                       TF_VAR_app_insights_name: "amido-stacks-nonprod-euw-core",
                       TF_VAR_app_gateway_frontend_ip_name: "amido-stacks-nonprod-euw-core",
@@ -270,7 +266,7 @@ stages:
                       TF_VAR_name_company: $(company),
                       TF_VAR_name_project: $(project),
                       TF_VAR_name_domain: $(domain),
-                      TF_VAR_create_cosmosdb: true,
+                      TF_VAR_create_cosmosdb: false,
                       TF_VAR_create_cache: false,
                       TF_VAR_stage: $(Environment.ShortName),
                       TF_VAR_dns_record: "$(Environment.ShortName)-${{ variables.domain }}",
@@ -298,12 +294,6 @@ stages:
             value: "$(azure-client-secret)"
           - name: ARM_TENANT_ID
             value: $(azure-tenant-id)
-          - name: cosmosdb_database_name
-            value: $[ dependencies.AppInfraDev.outputs['AppInfraDev.tfoutputs.cosmosdb_database_name'] ]
-          - name: cosmosdb_endpoint
-            value: $[ dependencies.AppInfraDev.outputs['AppInfraDev.tfoutputs.cosmosdb_endpoint'] ]
-          - name: cosmosdb_primary_master_key
-            value: $[ dependencies.AppInfraDev.outputs['AppInfraDev.tfoutputs.cosmosdb_primary_master_key'] ]
           - name: app_insights_instrumentation_key
             value: $[ dependencies.AppInfraDev.outputs['AppInfraDev.tfoutputs.app_insights_instrumentation_key'] ]
           - name: namespace
@@ -345,9 +335,6 @@ stages:
                           k8s_image: '$(k8s_docker_registry_nonprod)/$(docker_image_name):$(docker_image_tag)',
                           aadpodidentitybinding: stacks-webapp-identity,
                           app_insights_key: $(app_insights_instrumentation_key),
-                          cosmosdb_key: $(cosmosdb_primary_master_key),
-                          cosmosdb_endpoint: $(cosmosdb_endpoint),
-                          cosmosdb_name: $(cosmosdb_database_name),
                           jwtbearerauthentication_audience: "<TODO>",
                           jwtbearerauthentication_authority: "<TODO>",
                           jwtbearerauthentication_enabled: false,
@@ -450,10 +437,6 @@ stages:
                       TF_VAR_name_component: $(component),
                       TF_VAR_resource_group_location: $(region),
                       TF_VAR_create_cdn_endpoint: false,
-                      TF_VAR_cosmosdb_sql_container: "Menu",
-                      TF_VAR_cosmosdb_sql_container_partition_key: "/id",
-                      TF_VAR_cosmosdb_kind: "GlobalDocumentDB",
-                      TF_VAR_cosmosdb_offer_type: "Standard",
                       TF_VAR_create_dns_record: true,
                       TF_VAR_app_insights_name: "amido-stacks-prod-euw-core",
                       TF_VAR_app_gateway_frontend_ip_name: "amido-stacks-prod-euw-core",
@@ -461,7 +444,7 @@ stages:
                       TF_VAR_name_company: $(company),
                       TF_VAR_name_project: $(project),
                       TF_VAR_name_domain: $(domain),
-                      TF_VAR_create_cosmosdb: true,
+                      TF_VAR_create_cosmosdb: false,
                       TF_VAR_create_cache: false,
                       TF_VAR_stage: $(Environment.ShortName),
                       TF_VAR_dns_record: "$(Environment.ShortName)-${{ variables.domain }}",
@@ -528,12 +511,6 @@ stages:
             value: "$(prod-azure-client-secret)"
           - name: ARM_TENANT_ID
             value: $(prod-azure-tenant-id)
-          - name: cosmosdb_database_name
-            value: $[ dependencies.AppInfraProd.outputs['AppInfraProd.tfoutputs.cosmosdb_database_name'] ]
-          - name: cosmosdb_endpoint
-            value: $[ dependencies.AppInfraProd.outputs['AppInfraProd.tfoutputs.cosmosdb_endpoint'] ]
-          - name: cosmosdb_primary_master_key
-            value: $[ dependencies.AppInfraProd.outputs['AppInfraProd.tfoutputs.cosmosdb_primary_master_key'] ]
           - name: app_insights_instrumentation_key
             value: $[ dependencies.AppInfraProd.outputs['AppInfraProd.tfoutputs.app_insights_instrumentation_key'] ]
           - name: namespace
@@ -575,9 +552,6 @@ stages:
                           k8s_image: '$(k8s_docker_registry_prod)/$(docker_image_name):$(docker_image_tag)',
                           aadpodidentitybinding: stacks-webapp-identity,
                           app_insights_key: $(app_insights_instrumentation_key),
-                          cosmosdb_key: $(cosmosdb_primary_master_key),
-                          cosmosdb_endpoint: $(cosmosdb_endpoint),
-                          cosmosdb_name: $(cosmosdb_database_name),
                           jwtbearerauthentication_audience: "<TODO>",
                           jwtbearerauthentication_authority: "<TODO>",
                           jwtbearerauthentication_enabled: false,

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -273,6 +273,10 @@ stages:
                       TF_VAR_dns_zone_name: $(base_domain_nonprod),
                       TF_VAR_dns_zone_resource_group: "$(dns_zone_resource_group)",
                       TF_VAR_internal_dns_zone_name: $(base_domain_internal_nonprod),
+                      TF_VAR_cosmosdb_sql_container: "Menu",
+                      TF_VAR_cosmosdb_sql_container_partition_key: "/id",
+                      TF_VAR_cosmosdb_kind: "GlobalDocumentDB",
+                      TF_VAR_cosmosdb_offer_type: "Standard",
                     }
                     terraform_output_commands: |
                       raw_tf=$(terraform output -json | jq -r 'keys[] as $k | "##vso[task.setvariable variable=\($k);isOutput=true]\(.[$k] | .value)"')
@@ -451,6 +455,10 @@ stages:
                       TF_VAR_dns_zone_name: $(base_domain_prod),
                       TF_VAR_dns_zone_resource_group: "$(dns_zone_resource_group)",
                       TF_VAR_internal_dns_zone_name: $(base_domain_internal_prod),
+                      TF_VAR_cosmosdb_sql_container: "Menu",
+                      TF_VAR_cosmosdb_sql_container_partition_key: "/id",
+                      TF_VAR_cosmosdb_kind: "GlobalDocumentDB",
+                      TF_VAR_cosmosdb_offer_type: "Standard",
                     }
                     terraform_output_commands: |
                       raw_tf=$(terraform output -json | jq -r 'keys[] as $k | "##vso[task.setvariable variable=\($k);isOutput=true]\(.[$k] | .value)"')

--- a/deploy/k8s/app/base_api-deploy.yml
+++ b/deploy/k8s/app/base_api-deploy.yml
@@ -88,7 +88,6 @@ metadata:
   namespace: ${namespace}
 type: Opaque
 stringData:
-  cosmos_key: ${cosmosdb_key}
   app_insights: ${app_insights_key}
 
 ---
@@ -126,14 +125,6 @@ data:
           }
       },
       "AllowedHosts": "*",
-      "CosmosDb": {
-          "DatabaseAccountUri": "${cosmosdb_endpoint}",
-          "DatabaseName": "${cosmosdb_name}",
-          "SecurityKeySecret": {
-              "Identifier": "COSMOSDB_KEY",
-              "Source": "Environment"
-          }
-      },
       "JwtBearerAuthentication": {
           "Audience": "${jwtbearerauthentication_audience}",
           "Authority": "${jwtbearerauthentication_authority}",
@@ -242,11 +233,6 @@ spec:
                   fieldPath: metadata.annotations['release']
             - name: API_BASEPATH
               value: ${k8s_app_path}
-            - name: COSMOSDB_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: appsecrets
-                  key: cosmos_key
             - name: LOG_LEVEL
               value: debug
             - name: APPINSIGHTS_INSTRUMENTATIONKEY


### PR DESCRIPTION
#### 📲 What

Removed the deployment of CosmosDB from the build

#### 🤔 Why
		
The `stacks-dotnet` repo is now just a WebApi and as such does not require the deployment of CosmosDB
		
#### 🛠 How
		
Set the Terraform variable `create-cosmosdb` to false.
Removed references to keys int he variable group that are no longer required

Some of the other CosmoDB variables for TF have had to be left in as the module requires these values even when CosmosDB is not being deployed.

#### 👀 Evidence
		
All components are being built and deployed in AzDo
The tests are all passing.
		 
#### 🕵️ How to test

Test as normal

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
