### PR TITLE
[3301] Update pipeline to create GitHub release artifact

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -233,7 +233,7 @@ stages:
             displayName: Publish Templates
             inputs:
               path: $(Agent.BuildDirectory)/a
-              artifact: packages              
+              artifact: packages
 
   - stage: Dev
     dependsOn: Build

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -25,7 +25,7 @@ resources:
     - repository: templates
       type: github
       name: amido/stacks-pipeline-templates
-      ref: refs/tags/v2.0.2
+      ref: refs/tags/v2.0.3
       # EXCHANGE THIS FOR YOUR OWN ENDPOINT CONNECTION TO GITHUB
       # REPOSITORY IS PUBLIC
       endpoint: amidostacks
@@ -99,6 +99,10 @@ variables:
   # Yamllint
   yamllint_config_file: "${{ variables.self_repo_dir }}/yamllint.conf"
   yamllint_scan_directory: "."
+  # Release
+  create_release: true
+  github_release_service_connection: GitHubReleases
+  github_org: $(company)
 
 stages:
   - stage: Build
@@ -114,6 +118,8 @@ stages:
         value: "$(azure-client-id)"
       - name: azure_client_secret
         value: "$(azure-client-secret)"
+      - name: version_number
+        value: "$(version_major).$(version_minor).$(version_revision)"
     jobs:
       - job: AppBuild
         pool:
@@ -196,6 +202,38 @@ stages:
               functional_test: true
               functional_test_artefact: tests
               repo_name: $(self_repo)
+
+          # Copy the files into the correct place for packaging
+          - task: Bash@3
+            displayName: Prepare for Packaging
+            inputs:
+              targetType: "inline"
+              workingDirectory: $(Agent.BuildDirectory)/s
+              script: |
+                cp $REPO_NAME/template.csproj .
+                mkdir ./templates
+                pushd templates
+                cp -r ${ROOT_SRC_DIR}/$REPO_NAME .
+                cp -r ${ROOT_SRC_DIR}/$REPO_NAME/src/api .
+                popd
+
+            env:
+              ROOT_SRC_DIR: $(Agent.BuildDirectory)/s
+              REPO_NAME: $(self_repo)
+
+          # Call template to build the package from the templates dir
+          - template: azDevOps/azure/templates/v2/steps/build-pack-test-dotnet.yml@templates
+            parameters:
+              package_path: $(Agent.BuildDirectory)/s
+              dotnet_core_version: 3.1.x
+              version_variable_name: version_number
+
+          # Upload the packages as artefacts
+          - task: PublishPipelineArtifact@1
+            displayName: Publish Templates
+            inputs:
+              path: $(Agent.BuildDirectory)/a
+              artifact: packages              
 
   - stage: Dev
     dependsOn: Build
@@ -598,3 +636,56 @@ stages:
                     azure_client_secret: $(ARM_CLIENT_SECRET)
                     azure_tenant_id: $(ARM_TENANT_ID)
                     azure_subscription_id: $(ARM_SUBSCRIPTION_ID)
+
+  - stage: Release
+    dependsOn:
+      - Build
+      - Prod
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['create_release'], 'true'))
+    variables:
+      - group: amido-stacks-infra-credentials-nonprod
+      - name: version_number
+        value: "$(version_major).$(version_minor).$(version_revision)"
+    jobs:
+      - job: CreateGitHubRelease
+        pool:
+          vmImage: $(pool_vm_image)
+        steps:
+          # Check out the repo so that it can be tagged
+          - checkout: self
+            persistCredentials: true
+
+          # Download the artefacts from the build to create the release from
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'packages'
+              path: $(Build.ArtifactStagingDirectory)/packages
+
+          # Create a tag in the code for this release
+          - task: Bash@3
+            displayName: Tag Code
+            inputs:
+              targetType: "inline"
+              script: |
+                git config user.name "BuildService"
+                git config user.email "builder@${COMPANY}.com"
+
+                git tag -a v${VERSION_NUMBER} -m "Release created by Azure DevOps"
+                git push origin v${VERSION_NUMBER}
+            env:
+              COMPANY: $(company)
+
+          # Create a GitHub release with these packages
+          - task: GitHubRelease@0
+            displayName: Create GitHub Release
+            inputs:
+              gitHubConnection: $(github_release_service_connection)
+              repositoryName: $(github_org)/$(self_repo)
+              tag: $(Build.BuildNumber)
+              assets: |
+                $(Build.ArtifactStagingDirectory)/packages/*.nupkg
+
+          # Push the package to Nuget
+          - template: azDevOps/azure/templates/v2/steps/deploy-push-package-symbols-public.yml@templates
+            parameters:
+              nuget_sevice_connection: $(nuget_service_connection)

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -214,7 +214,6 @@ stages:
                 mkdir ./templates
                 pushd templates
                 cp -r ${ROOT_SRC_DIR}/$REPO_NAME .
-                cp -r ${ROOT_SRC_DIR}/$REPO_NAME/src/api .
                 popd
 
             env:


### PR DESCRIPTION
📲 What

Added steps to the Build stage to create the Nuget packages for the templates and upload them as a build artefact
Added new stage, Release, to create a new GitHub release for the project and upload the Nuget package to Nuget

🤔 Why

So that people are able to add additional code to an existing project the templates need to be built as a Nuget package and uploaded to Nuget
The packages are also added as part of a GitHub release so that the Stacks CLI can download them when preparing a new project on a users machine

🛠 How

Added some new steps to the build:

    create the file structure for the nuget pack command to run
    use an existing template to create the nuget package with the appropriate version number
    upload the template package as a pipeline artefact

Added a new Release stage at the end of the pipeline. This is only run from master and can be controlled using a variable

    download package as an artefact from the pipeline
    tag the code with the version number so it is possible to clone the code at the point at which the package was created
    create a new GitHub release on the repository
    Upload the nuget package to Nuget using an existing template

👀 Evidence

The package is uploaded as an artefact to Azure DevOps

![image](https://user-images.githubusercontent.com/791658/130624847-22796d87-ed2e-448a-ba93-7e069fe68ca0.png)
