### PR TITLE
Fix URL for functional tests

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -25,7 +25,7 @@ resources:
     - repository: templates
       type: github
       name: amido/stacks-pipeline-templates
-      ref: refs/tags/v2.0.3
+      ref: refs/tags/v2.0.4
       # EXCHANGE THIS FOR YOUR OWN ENDPOINT CONNECTION TO GITHUB
       # REPOSITORY IS PUBLIC
       endpoint: amidostacks
@@ -391,11 +391,18 @@ stages:
                       }
                     ]
 
+                # Upload the deployment manifest as an artefact
+                - task: PublishPipelineArtifact@1
+                  displayName: Publish K8s Manifest
+                  inputs:
+                    path: $(self_repo_dir)/deploy/k8s/app/api-deploy.yml
+                    artifact: manifests_dev
+
                 - template: azDevOps/azure/templates/v2/steps/deploy-k8s-app-kubectl.yml@templates
                   parameters:
                     scripts_dir: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
                     test_artefact: "tests"
-                    test_baseurl: ""
+                    test_baseurl: "https://$(Environment.ShortName)-${{ variables.domain }}.$(base_domain_nonprod)/api/menu/"
                     functional_test: true
                     performance_test: false
                     smoke_test: false
@@ -612,11 +619,18 @@ stages:
                       }
                     ]
 
+                # Upload the deployment manifest as an artefact
+                - task: PublishPipelineArtifact@1
+                  displayName: Publish K8s Manifest
+                  inputs:
+                    path: $(self_repo_dir)/deploy/k8s/app/api-deploy.yml
+                    artifact: manifests_prod
+
                 - template: azDevOps/azure/templates/v2/steps/deploy-k8s-app-kubectl.yml@templates
                   parameters:
                     scripts_dir: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
                     test_artefact: "tests"
-                    test_baseurl: ""
+                    test_baseurl: "https://$(Environment.ShortName)-${{ variables.domain }}.$(base_domain_prod)/api/menu/"
                     functional_test: true
                     performance_test: false
                     smoke_test: false


### PR DESCRIPTION
📲 What

Correct the URL that is used by the functional tests

🤔 Why

In the prod environment the tests were pointing to the dev environment

Additionally the Kubernetes manifests for Dev and Prod are being uploaded as artefacts of the pipeline.

🛠 How

By updating the stacks-pipeline-templates to use the tests_baseurl the URL for the tests can now be overridden by setting this variable. Internally the value is set as BaseUrl environment variable which the tests will pick up.

👀 Evidence

The tests are passing and the URLs can be seen in the logs of the app.

The environment variable is being set in the pipeline:

![image](https://user-images.githubusercontent.com/791658/131380255-3102d55d-1284-45aa-8f6c-4df621e63ef7.png)


🕵️ How to test

Notes for QA
✅ Acceptance criteria Checklist

Code peer reviewed?
Documentation has been updated to reflect the changes?
Passing all automated tests, including a successful deployment?
Passing any exploratory testing?
Rebased/merged with latest changes from development and re-tested?
Meeting the Coding Standards?