### PR TITLE
Change the base url to the local host

### DIFF
--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/ReadMe.md
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/ReadMe.md
@@ -1,7 +1,8 @@
 # Amido Stacks Automated Functional Testing
 
-The full documentation on Amido Stacks can be found [here](https://amido.github.io/stacks/).
+The full documentation on Amido Stacks can be found [here](https://github.com/amido/stacks-dotnet).
+
 
 Amido Stacks targets different cloud providers.
 
-[Azure](https://amido.github.io/stacks/docs/workloads/azure/backend/netcore/testing/functional_testing_netcore)
+[Azure](https://stacks.amido.com/docs/workloads/azure/backend/netcore/testing/functional_testing_netcore/)

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/appsettings.json
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/appsettings.json
@@ -1,3 +1,3 @@
 {
-  "BaseUrl": "https://dev-netcore-api.nonprod.amidostacks.com/api/menu/",
+  "BaseUrl": "http://localhost:5000/"
 }


### PR DESCRIPTION
#### 📲 What
Changed the base URL to localhost from the amido dev environment URL. This doesn't work especially when the web-api template is used to replace the domain name but still uses the amido dev environment. 

#### 🤔 Why	
In the template, having amido dev environment URL does make no sense as it is an invalid URL for the template users.
	

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
