### PR TITLE
[3642] Use variable template for stacks-dotnet

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -45,20 +45,27 @@ variables:
   #domain: netcore-api
 - name: component
   value: api
-  
-  role: backend
+
+- name: role
+  value: backend
   #
   # SelfConfig
   # If you haven't specified source_repo at cli runtime please ensure you replace it here
   # It is case sensitive for TFS based repos
   #self_repo: stacks-dotnet
-  self_repo_src: src/api
-  self_repo_dir: "$(Agent.BuildDirectory)/s/$(self_repo)"
-  self_repo_tf_src: deploy/azure/app/kube
-  self_repo_tf_dir: "$(self_repo_dir)/$(self_repo_tf_src)"
+- name: self_repo_src
+  value: src/api
+- name: self_repo_dir
+  value: "$(Agent.BuildDirectory)/s/$(self_repo)"
+- name: self_repo_tf_src
+  value: deploy/azure/app/kube
+- name: self_repo_tf_dir
+  value: "$(self_repo_dir)/$(self_repo_tf_src)"
   #self_generic_name: stacks-api
-  self_pipeline_repo: "$(Agent.BuildDirectory)/s/stacks-pipeline-templates"
-  self_pipeline_scripts_dir: "$(self_pipeline_repo)/scripts"
+- name: self_pipeline_repo
+  value: "$(Agent.BuildDirectory)/s/stacks-pipeline-templates"
+- name: self_pipeline_scripts_dir
+  value: "$(self_pipeline_repo)/scripts"
   # TF STATE CONFIG
   #tf_state_rg: "Stacks-Ancillary-Resources"
   #tf_state_storage: "amidostackstfstate"
@@ -73,22 +80,33 @@ variables:
   #tf_state_key: "netcore-api"
   # Environment
   # Set the name of the resource group that has the DNS zones to be updated
-  dns_zone_resource_group: "Stacks-Ancillary-Resources"
+- name: dns_zone_resource_group
+  value: "Stacks-Ancillary-Resources"
   # Versioning
-  version_major: 0
-  version_minor: 0
-  version_revision: $[counter(join(variables['version_major'], join('-', variables['version_minor'])), 0)]
+- name: version_major
+  value: 0
+- name: version_minor
+  value: 0
+- name: version_revision
+  value: $[counter(join(variables['version_major'], join('-', variables['version_minor'])), 0)]
   # Docker Config
-  docker_dockerfile_path: "src/api"
-  docker_image_name: $(self_generic_name)
-  docker_image_tag: "$(version_major).$(version_minor).$(version_revision)-$(Build.SourceBranchName)"
+- name: docker_dockerfile_path
+  value: "src/api"
+- name: docker_image_name
+  value: $(self_generic_name)
+- name: docker_image_tag
+  value: "$(version_major).$(version_minor).$(version_revision)-$(Build.SourceBranchName)"
   #docker_container_registry_name_nonprod: amidostacksnonprodeuwcore
-  k8s_docker_registry_nonprod: $(docker_container_registry_name_nonprod).azurecr.io
+- name: k8s_docker_registry_nonprod
+  value: $(docker_container_registry_name_nonprod).azurecr.io
   #docker_container_registry_name_prod: amidostacksprodeuwcore
-  k8s_docker_registry_prod: $(docker_container_registry_name_prod).azurecr.io
-  resource_def_name: dotnet-api
+- name: k8s_docker_registry_prod
+  value: $(docker_container_registry_name_prod).azurecr.io
+- name: resource_def_name
+  value: dotnet-api
   # Scripts directory used by pipeline steps
-  scripts_dir: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
+- name: scripts_dir
+  value: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
   # Infra
   #region: "westeurope"
   #base_domain_nonprod: nonprod.amidostacks.com
@@ -96,12 +114,16 @@ variables:
   #base_domain_prod: prod.amidostacks.com
   #base_domain_internal_prod: prod.amidostacks.internal
   # DEFAULT IMAGE RUNNER
-  pool_vm_image: ubuntu-20.04
+- name: pool_vm_image
+  value: ubuntu-20.04
   # Test setup
-  code_coverage_cobertura_directory: coverage
+- name: code_coverage_cobertura_directory
+  value: coverage
   # Yamllint
-  yamllint_config_file: "${{ variables.self_repo_dir }}/yamllint.conf"
-  yamllint_scan_directory: "."
+- name: yamllint_config_file
+  value: "${{ variables.self_repo_dir }}/yamllint.conf"
+- name: yamllint_scan_directory
+  value: "."
 
 stages:
   - stage: Build

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -39,91 +39,71 @@ resources:
       image: amidostacks/ci-tf:0.0.8
 
 variables:
-- template: azuredevops-vars.yml
-  #company: amido
-  #project: stacks
-  #domain: netcore-api
-- name: component
-  value: api
+  - template: azuredevops-vars.yml
 
-- name: role
-  value: backend
+  - name: component
+    value: api
+
+  - name: role
+    value: backend
   #
   # SelfConfig
   # If you haven't specified source_repo at cli runtime please ensure you replace it here
   # It is case sensitive for TFS based repos
-  #self_repo: stacks-dotnet
-- name: self_repo_src
-  value: src/api
-- name: self_repo_dir
-  value: "$(Agent.BuildDirectory)/s/$(self_repo)"
-- name: self_repo_tf_src
-  value: deploy/azure/app/kube
-- name: self_repo_tf_dir
-  value: "$(self_repo_dir)/$(self_repo_tf_src)"
-  #self_generic_name: stacks-api
-- name: self_pipeline_repo
-  value: "$(Agent.BuildDirectory)/s/stacks-pipeline-templates"
-- name: self_pipeline_scripts_dir
-  value: "$(self_pipeline_repo)/scripts"
-  # TF STATE CONFIG
-  #tf_state_rg: "Stacks-Ancillary-Resources"
-  #tf_state_storage: "amidostackstfstate"
-  #tf_state_container: "tfstate"
-  # Stacks operates Terraform states based on workspaces **IT IS VERY IMPORTANT** that you ensure a unique name for each application definition
-  # Furthermore **IT IS VERY IMPORTANT** that you change the name of a workspace for each deployment stage
-  # there are some best practices around this if you are going for feature based environments
-  # - we suggest you create a runtime variable that is dynamically set based on a branch currently running
-  # **`terraform_state_workspace: `**
-  # avoid running anything past dev that is not on master
-  # sample value: company-webapp
-  #tf_state_key: "netcore-api"
+  - name: self_repo_src
+    value: src/api
+  - name: self_repo_dir
+    value: "$(Agent.BuildDirectory)/s/$(self_repo)"
+  - name: self_repo_tf_src
+    value: deploy/azure/app/kube
+  - name: self_repo_tf_dir
+    value: "$(self_repo_dir)/$(self_repo_tf_src)"
+
+  - name: self_pipeline_repo
+    value: "$(Agent.BuildDirectory)/s/stacks-pipeline-templates"
+  - name: self_pipeline_scripts_dir
+    value: "$(self_pipeline_repo)/scripts"
+
   # Environment
   # Set the name of the resource group that has the DNS zones to be updated
-- name: dns_zone_resource_group
-  value: "Stacks-Ancillary-Resources"
+  - name: dns_zone_resource_group
+    value: "Stacks-Ancillary-Resources"
   # Versioning
-- name: version_major
-  value: 0
-- name: version_minor
-  value: 0
-- name: version_revision
-  value: $[counter(join(variables['version_major'], join('-', variables['version_minor'])), 0)]
+  - name: version_major
+    value: 0
+  - name: version_minor
+    value: 0
+  - name: version_revision
+    value: $[counter(join(variables['version_major'], join('-', variables['version_minor'])), 0)]
   # Docker Config
-- name: docker_dockerfile_path
-  value: "src/api"
-- name: docker_image_name
-  value: $(self_generic_name)
-- name: docker_image_tag
-  value: "$(version_major).$(version_minor).$(version_revision)-$(Build.SourceBranchName)"
-  #docker_container_registry_name_nonprod: amidostacksnonprodeuwcore
-- name: k8s_docker_registry_nonprod
-  value: $(docker_container_registry_name_nonprod).azurecr.io
-  #docker_container_registry_name_prod: amidostacksprodeuwcore
-- name: k8s_docker_registry_prod
-  value: $(docker_container_registry_name_prod).azurecr.io
-- name: resource_def_name
-  value: dotnet-api
+  - name: docker_dockerfile_path
+    value: "src/api"
+  - name: docker_image_name
+    value: $(self_generic_name)
+  - name: docker_image_tag
+    value: "$(version_major).$(version_minor).$(version_revision)-$(Build.SourceBranchName)"
+
+  - name: k8s_docker_registry_nonprod
+    value: $(docker_container_registry_name_nonprod).azurecr.io
+
+  - name: k8s_docker_registry_prod
+    value: $(docker_container_registry_name_prod).azurecr.io
+  - name: resource_def_name
+    value: dotnet-api
   # Scripts directory used by pipeline steps
-- name: scripts_dir
-  value: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
-  # Infra
-  #region: "westeurope"
-  #base_domain_nonprod: nonprod.amidostacks.com
-  #base_domain_internal_nonprod: nonprod.amidostacks.internal
-  #base_domain_prod: prod.amidostacks.com
-  #base_domain_internal_prod: prod.amidostacks.internal
+  - name: scripts_dir
+    value: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
   # DEFAULT IMAGE RUNNER
-- name: pool_vm_image
-  value: ubuntu-20.04
+  - name: pool_vm_image
+    value: ubuntu-20.04
   # Test setup
-- name: code_coverage_cobertura_directory
-  value: coverage
+  - name: code_coverage_cobertura_directory
+    value: coverage
   # Yamllint
-- name: yamllint_config_file
-  value: "${{ variables.self_repo_dir }}/yamllint.conf"
-- name: yamllint_scan_directory
-  value: "."
+  - name: yamllint_config_file
+    value: "${{ variables.self_repo_dir }}/yamllint.conf"
+  - name: yamllint_scan_directory
+    value: "."
 
 stages:
   - stage: Build

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -39,27 +39,28 @@ resources:
       image: amidostacks/ci-tf:0.0.8
 
 variables:
-  company: amido
-  project: stacks
-  domain: netcore-api
+- template: azuredevops-vars.yml
+  #company: amido
+  #project: stacks
+  #domain: netcore-api
   component: api
   role: backend
   #
   # SelfConfig
   # If you haven't specified source_repo at cli runtime please ensure you replace it here
   # It is case sensitive for TFS based repos
-  self_repo: stacks-dotnet
+  #self_repo: stacks-dotnet
   self_repo_src: src/api
   self_repo_dir: "$(Agent.BuildDirectory)/s/$(self_repo)"
   self_repo_tf_src: deploy/azure/app/kube
   self_repo_tf_dir: "$(self_repo_dir)/$(self_repo_tf_src)"
-  self_generic_name: stacks-api
+  #self_generic_name: stacks-api
   self_pipeline_repo: "$(Agent.BuildDirectory)/s/stacks-pipeline-templates"
   self_pipeline_scripts_dir: "$(self_pipeline_repo)/scripts"
   # TF STATE CONFIG
-  tf_state_rg: "Stacks-Ancillary-Resources"
-  tf_state_storage: "amidostackstfstate"
-  tf_state_container: "tfstate"
+  #tf_state_rg: "Stacks-Ancillary-Resources"
+  #tf_state_storage: "amidostackstfstate"
+  #tf_state_container: "tfstate"
   # Stacks operates Terraform states based on workspaces **IT IS VERY IMPORTANT** that you ensure a unique name for each application definition
   # Furthermore **IT IS VERY IMPORTANT** that you change the name of a workspace for each deployment stage
   # there are some best practices around this if you are going for feature based environments
@@ -67,7 +68,7 @@ variables:
   # **`terraform_state_workspace: `**
   # avoid running anything past dev that is not on master
   # sample value: company-webapp
-  tf_state_key: "netcore-api"
+  #tf_state_key: "netcore-api"
   # Environment
   # Set the name of the resource group that has the DNS zones to be updated
   dns_zone_resource_group: "Stacks-Ancillary-Resources"
@@ -79,19 +80,19 @@ variables:
   docker_dockerfile_path: "src/api"
   docker_image_name: $(self_generic_name)
   docker_image_tag: "$(version_major).$(version_minor).$(version_revision)-$(Build.SourceBranchName)"
-  docker_container_registry_name_nonprod: amidostacksnonprodeuwcore
+  #docker_container_registry_name_nonprod: amidostacksnonprodeuwcore
   k8s_docker_registry_nonprod: $(docker_container_registry_name_nonprod).azurecr.io
-  docker_container_registry_name_prod: amidostacksprodeuwcore
+  #docker_container_registry_name_prod: amidostacksprodeuwcore
   k8s_docker_registry_prod: $(docker_container_registry_name_prod).azurecr.io
   resource_def_name: dotnet-api
   # Scripts directory used by pipeline steps
   scripts_dir: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
   # Infra
-  region: "westeurope"
-  base_domain_nonprod: nonprod.amidostacks.com
-  base_domain_internal_nonprod: nonprod.amidostacks.internal
-  base_domain_prod: prod.amidostacks.com
-  base_domain_internal_prod: prod.amidostacks.internal
+  #region: "westeurope"
+  #base_domain_nonprod: nonprod.amidostacks.com
+  #base_domain_internal_nonprod: nonprod.amidostacks.internal
+  #base_domain_prod: prod.amidostacks.com
+  #base_domain_internal_prod: prod.amidostacks.internal
   # DEFAULT IMAGE RUNNER
   pool_vm_image: ubuntu-20.04
   # Test setup

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -64,10 +64,6 @@ variables:
   - name: self_pipeline_scripts_dir
     value: "$(self_pipeline_repo)/scripts"
 
-  # Environment
-  # Set the name of the resource group that has the DNS zones to be updated
-  - name: dns_zone_resource_group
-    value: "Stacks-Ancillary-Resources"
   # Versioning
   - name: version_major
     value: 0

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -43,7 +43,9 @@ variables:
   #company: amido
   #project: stacks
   #domain: netcore-api
-  component: api
+- name: component
+  value: api
+  
   role: backend
   #
   # SelfConfig

--- a/build/azDevOps/azure/azuredevops-vars.yml
+++ b/build/azDevOps/azure/azuredevops-vars.yml
@@ -1,0 +1,35 @@
+variables:
+  - name: company
+    value: amido
+  - name: project
+    value: stacks
+  - name: domain
+    value: netcore-api
+  - name: self-repo
+    value: stacks-dotnet
+  - name: self-generic-name
+    value: stacks-api
+  - name: tf_state_rg
+    value: Stacks-Ancillary-Resources
+  - name: tf_state_storage
+    value: amidostackstfstate
+  - name: tf_state_container
+    value: tfstate
+  - name: tf_state_key
+    value: netcore-api
+  - name: docker_container_registry_name_nonprod
+    value: amidostacksnonprodeuwcore
+  - name: docker_container_registry_name_prod
+    value: amidostacksprodeuwcore
+  - name: region
+    value: westeurope
+  - name: base_domain_nonprod
+    value: nonprod.amidostacks.com    
+  - name: base_domain_internal_nonprod
+    value: nonprod.amidostacks.internal
+  - name: base_domain_prod
+    value: prod.amidostacks.com
+  - name: base_domain_internal_prod
+    value: prod.amidostacks.internal
+  
+  

--- a/build/azDevOps/azure/azuredevops-vars.yml
+++ b/build/azDevOps/azure/azuredevops-vars.yml
@@ -41,3 +41,8 @@ variables:
     value: prod.amidostacks.com
   - name: base_domain_internal_prod
     value: prod.amidostacks.internal
+
+  # Environment
+  # Set the name of the resource group that has the DNS zones to be updated
+  - name: dns_zone_resource_group
+    value: "Stacks-Ancillary-Resources"    

--- a/build/azDevOps/azure/azuredevops-vars.yml
+++ b/build/azDevOps/azure/azuredevops-vars.yml
@@ -24,12 +24,10 @@ variables:
   - name: region
     value: westeurope
   - name: base_domain_nonprod
-    value: nonprod.amidostacks.com    
+    value: nonprod.amidostacks.com
   - name: base_domain_internal_nonprod
     value: nonprod.amidostacks.internal
   - name: base_domain_prod
     value: prod.amidostacks.com
   - name: base_domain_internal_prod
     value: prod.amidostacks.internal
-  
-  

--- a/build/azDevOps/azure/azuredevops-vars.yml
+++ b/build/azDevOps/azure/azuredevops-vars.yml
@@ -5,10 +5,20 @@ variables:
     value: stacks
   - name: domain
     value: netcore-api
-  - name: self-repo
+  - name: self_repo
     value: stacks-dotnet
-  - name: self-generic-name
+  - name: self_generic_name
     value: stacks-api
+
+  # TF STATE CONFIG
+
+  # Stacks operates Terraform states based on workspaces **IT IS VERY IMPORTANT** that you ensure a unique name for each application definition
+  # Furthermore **IT IS VERY IMPORTANT** that you change the name of a workspace for each deployment stage
+  # there are some best practices around this if you are going for feature based environments
+  # - we suggest you create a runtime variable that is dynamically set based on a branch currently running
+  # **`terraform_state_workspace: `**
+  # avoid running anything past dev that is not on master
+  # sample value: company-webapp
   - name: tf_state_rg
     value: Stacks-Ancillary-Resources
   - name: tf_state_storage


### PR DESCRIPTION
#### 📲 What

Move the variables into a variable template

#### 🤔 Why
		
Updating the variables in the main template automatically is hard because the values could change.
By moving the vars into a separate file the Stacks CLI can create the file as required without needing to update.
		
#### 🛠 How
		
Using the Azure DevOps variable template pattern and then import this into the main build file.

To accommodate this the syntax for declaring variables has changed from key value pair to explicit "name" and "value" keys.

#### 👀 Evidence
		
The build is passing with no errors meaning that the variables are being read in as required.
		 
#### 🕵️ How to test

As usual

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
