### PR TITLE
fix(base-api): increase timeout value for alb ingress using custom at…

### DIFF
--- a/deploy/k8s/aws/base_api-deploy.yml
+++ b/deploy/k8s/aws/base_api-deploy.yml
@@ -13,6 +13,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=120 # resolved 502 error while deployment "https://www.tessian.com/blog/how-to-fix-http-502-errors/"
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:eu-west-2:316154162729:certificate/17e50dfb-9fdc-4dce-92c1-8351a3961279 # This needs to be amended specifically
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
     alb.ingress.kubernetes.io/healthcheck-port: traffic-port

--- a/deploy/k8s/aws/base_api-deploy.yml
+++ b/deploy/k8s/aws/base_api-deploy.yml
@@ -54,7 +54,7 @@ spec:
             # path: ${k8s_app_route}(/|$)(.*)
             # pathType: ImplementationSpecific
             path: ${k8s_app_route}/*
-            pathType: Prefix
+            pathType: ImplementationSpecific
 ---
 
 apiVersion: v1


### PR DESCRIPTION
…tribute annotations

[XXXX-<Title> - Please use the Work Item number and Title as PR Name, not subtasks]

#### 📲 What
increase timeout value for alb ingress using custom annotations

#### 🤔 Why

To fix 502 error during ingress deployment 

https://www.tessian.com/blog/how-to-fix-http-502-errors/

#### 🛠 How

By using custom annotation for alb ingress to modify timeout value

#### 👀 Evidence

![image](https://user-images.githubusercontent.com/65091252/170896834-5559dc4c-ea12-43e9-8333-e10cec688c15.png)

![image](https://user-images.githubusercontent.com/65091252/170897555-f23923a8-7d9f-4462-a6e7-9378893cc296.png)


#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
