### PR TITLE
BUGFIX: Amends vars for prod cluster deployment

### DIFF
--- a/build/azDevOps/azure/air-api.yml
+++ b/build/azDevOps/azure/air-api.yml
@@ -381,8 +381,8 @@ stages:
                     # Check base_ prefixed file at $(k8s_resource_file) to see what should be replaced.
                     # The file deployment_list.ps1 can contain custom mappings, otherwise
                     # all other ${var} syntax entries will be replaced with like named env vars
-                    K8S_CLUSTER_TARGET: $(k8s_cluster_target_nonprod)
-                    K8S_CLUSTER_IDENTIFIER: $(k8s_cluster_identifier_nonprod)
+                    K8S_CLUSTER_TARGET: $(k8s_cluster_target_prod)
+                    K8S_CLUSTER_IDENTIFIER: $(k8s_cluster_identifier_prod)
                     K8S_RESOURCE_FILE: $(k8s_resource_file)
                     # Helm Config
                     HELM_VALUE_FILEPATH: ${helm_value_file}


### PR DESCRIPTION
#### 📲 What

Updates var usage for prod cluster deployment

#### 🤔 Why
		
During refactor at some point the nonprod var names were copied, and so prod deployments were going to the nonprod cluster.
		
#### 🛠 How
		
Standard YML

#### 👀 Evidence

Problem shown here, note cluster context:		
```
15:43:44 in ~ at ☸️  v1.24.6 amido-stacks-nonprod-euw-core  took 10s
➜ k get ns
NAME                             STATUS   AGE
argo-rollouts                    Active   126d
...
prod-netcore-api                 Active   438d
prod-netcore-api-cqrs            Active   438d
```

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
